### PR TITLE
Update tooling & Django support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ classifiers =
     Development Status :: 5 - Production/Stable
     Framework :: Django
     Framework :: Django :: 3.2
+    Framework :: Django :: 4.1
     Intended Audience :: Developers
     Operating System :: Unix
     Operating System :: MacOS
@@ -35,7 +36,7 @@ scripts =
   bin/patch_content_types
   bin/use_external_components
 install_requires =
-    django>=3.2.0
+    django>=3.2.0,<4.2
     django-choices
     django-filter>=2.0
     django-solo

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ install_requires =
     gemma-zds-client>=0.14.0
     iso-639
     isodate
-    notifications-api-common
+    notifications-api-common>=0.2.2
     oyaml
     PyJWT>=2.0.0
     pyyaml

--- a/testapp/migrations/0001_initial.py
+++ b/testapp/migrations/0001_initial.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/testapp/migrations/0002_auto_20190620_0849.py
+++ b/testapp/migrations/0002_auto_20190620_0849.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("testapp", "0001_initial")]
 
     operations = [

--- a/testapp/migrations/0003_auto_20200416_0423.py
+++ b/testapp/migrations/0003_auto_20200416_0423.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("testapp", "0002_auto_20190620_0849"),
     ]

--- a/testapp/migrations/0003_person__etag.py
+++ b/testapp/migrations/0003_person__etag.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("testapp", "0002_auto_20190620_0849")]
 
     operations = [

--- a/testapp/migrations/0004_auto_20190909_0206.py
+++ b/testapp/migrations/0004_auto_20190909_0206.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("testapp", "0003_person__etag")]
 
     operations = [

--- a/testapp/migrations/0005_group_name.py
+++ b/testapp/migrations/0005_group_name.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("testapp", "0004_auto_20190909_0206")]
 
     operations = [

--- a/testapp/migrations/0006_merge_20200416_0440.py
+++ b/testapp/migrations/0006_merge_20200416_0440.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("testapp", "0003_auto_20200416_0423"),
         ("testapp", "0005_group_name"),

--- a/vng_api_common/audittrails/migrations/0001_initial.py
+++ b/vng_api_common/audittrails/migrations/0001_initial.py
@@ -8,7 +8,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/vng_api_common/audittrails/migrations/0002_auto_20190516_0830.py
+++ b/vng_api_common/audittrails/migrations/0002_auto_20190516_0830.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("audittrails", "0001_initial")]
 
     operations = [

--- a/vng_api_common/audittrails/migrations/0003_auto_20190517_0844.py
+++ b/vng_api_common/audittrails/migrations/0003_auto_20190517_0844.py
@@ -8,7 +8,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("audittrails", "0002_auto_20190516_0830")]
 
     operations = [

--- a/vng_api_common/audittrails/migrations/0004_auto_20190520_1238.py
+++ b/vng_api_common/audittrails/migrations/0004_auto_20190520_1238.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("audittrails", "0003_auto_20190517_0844")]
 
     operations = [

--- a/vng_api_common/audittrails/migrations/0005_auto_20190520_1450.py
+++ b/vng_api_common/audittrails/migrations/0005_auto_20190520_1450.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("audittrails", "0004_auto_20190520_1238")]
 
     operations = [

--- a/vng_api_common/audittrails/migrations/0006_audittrail_toelichting.py
+++ b/vng_api_common/audittrails/migrations/0006_audittrail_toelichting.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("audittrails", "0005_auto_20190520_1450")]
 
     operations = [

--- a/vng_api_common/audittrails/migrations/0007_auto_20190522_0916.py
+++ b/vng_api_common/audittrails/migrations/0007_auto_20190522_0916.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("audittrails", "0006_audittrail_toelichting")]
 
     operations = [

--- a/vng_api_common/audittrails/migrations/0008_audittrail_resource_weergave.py
+++ b/vng_api_common/audittrails/migrations/0008_audittrail_resource_weergave.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("audittrails", "0007_auto_20190522_0916")]
 
     operations = [

--- a/vng_api_common/audittrails/migrations/0009_auto_20190712_1643.py
+++ b/vng_api_common/audittrails/migrations/0009_auto_20190712_1643.py
@@ -9,7 +9,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("audittrails", "0008_audittrail_resource_weergave")]
 
     operations = [

--- a/vng_api_common/audittrails/migrations/0010_audittrail_request_id.py
+++ b/vng_api_common/audittrails/migrations/0010_audittrail_request_id.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("audittrails", "0009_auto_20190712_1643")]
 
     operations = [

--- a/vng_api_common/audittrails/migrations/0011_auto_20190918_1335.py
+++ b/vng_api_common/audittrails/migrations/0011_auto_20190918_1335.py
@@ -6,7 +6,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("audittrails", "0010_audittrail_request_id")]
 
     operations = [

--- a/vng_api_common/audittrails/migrations/0012_auto_20200619_0545.py
+++ b/vng_api_common/audittrails/migrations/0012_auto_20200619_0545.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("audittrails", "0011_auto_20190918_1335"),
     ]

--- a/vng_api_common/audittrails/migrations/0012_remove_audittrail_request_id.py
+++ b/vng_api_common/audittrails/migrations/0012_remove_audittrail_request_id.py
@@ -6,7 +6,6 @@ from ._operations import RemoveField
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("audittrails", "0011_auto_20190918_1335"),
     ]

--- a/vng_api_common/audittrails/migrations/0013_audittrail_logrecord_id.py
+++ b/vng_api_common/audittrails/migrations/0013_audittrail_logrecord_id.py
@@ -6,7 +6,6 @@ from ._operations import AddField
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("audittrails", "0012_remove_audittrail_request_id"),
     ]

--- a/vng_api_common/audittrails/migrations/0013_auto_20201207_0846.py
+++ b/vng_api_common/audittrails/migrations/0013_auto_20201207_0846.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("audittrails", "0012_auto_20200619_0545"),
     ]

--- a/vng_api_common/audittrails/migrations/0014_auto_20201221_0905.py
+++ b/vng_api_common/audittrails/migrations/0014_auto_20201221_0905.py
@@ -6,7 +6,6 @@ from ._operations import AddField, RemoveField
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("audittrails", "0013_auto_20201207_0846"),
     ]

--- a/vng_api_common/audittrails/migrations/0014_auto_20210323_1654.py
+++ b/vng_api_common/audittrails/migrations/0014_auto_20210323_1654.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("audittrails", "0013_audittrail_logrecord_id"),
     ]

--- a/vng_api_common/audittrails/migrations/0015_auto_20220318_1608.py
+++ b/vng_api_common/audittrails/migrations/0015_auto_20220318_1608.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("audittrails", "0014_auto_20201221_0905"),
     ]

--- a/vng_api_common/audittrails/migrations/0016_merge_20220607_0517.py
+++ b/vng_api_common/audittrails/migrations/0016_merge_20220607_0517.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("audittrails", "0015_auto_20220318_1608"),
         ("audittrails", "0014_auto_20210323_1654"),

--- a/vng_api_common/audittrails/migrations/0017_alter_audittrail_bron.py
+++ b/vng_api_common/audittrails/migrations/0017_alter_audittrail_bron.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("audittrails", "0016_merge_20220607_0517"),
     ]

--- a/vng_api_common/audittrails/migrations/0018_auto_20221212_0745.py
+++ b/vng_api_common/audittrails/migrations/0018_auto_20221212_0745.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("audittrails", "0017_alter_audittrail_bron"),
     ]

--- a/vng_api_common/authorizations/migrations/0001_initial.py
+++ b/vng_api_common/authorizations/migrations/0001_initial.py
@@ -11,7 +11,6 @@ import vng_api_common.models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/vng_api_common/authorizations/migrations/0002_authorizationsconfig.py
+++ b/vng_api_common/authorizations/migrations/0002_authorizationsconfig.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("authorizations", "0001_initial")]
 
     operations = [

--- a/vng_api_common/authorizations/migrations/0003_auto_20190502_0409.py
+++ b/vng_api_common/authorizations/migrations/0003_auto_20190502_0409.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("authorizations", "0002_authorizationsconfig")]
 
     operations = [

--- a/vng_api_common/authorizations/migrations/0004_auto_20190503_0941.py
+++ b/vng_api_common/authorizations/migrations/0004_auto_20190503_0941.py
@@ -6,7 +6,6 @@ import vng_api_common.fields
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("authorizations", "0003_auto_20190502_0409")]
 
     operations = [

--- a/vng_api_common/authorizations/migrations/0005_auto_20190506_0842.py
+++ b/vng_api_common/authorizations/migrations/0005_auto_20190506_0842.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("authorizations", "0004_auto_20190503_0941")]
 
     operations = [

--- a/vng_api_common/authorizations/migrations/0006_auto_20190506_0901.py
+++ b/vng_api_common/authorizations/migrations/0006_auto_20190506_0901.py
@@ -8,7 +8,6 @@ import vng_api_common.fields
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("authorizations", "0005_auto_20190506_0842")]
 
     operations = [

--- a/vng_api_common/authorizations/migrations/0007_auto_20190506_1212.py
+++ b/vng_api_common/authorizations/migrations/0007_auto_20190506_1212.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("authorizations", "0006_auto_20190506_0901")]
 
     operations = [

--- a/vng_api_common/authorizations/migrations/0008_auto_20190712_1541.py
+++ b/vng_api_common/authorizations/migrations/0008_auto_20190712_1541.py
@@ -6,7 +6,6 @@ import vng_api_common.fields
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("authorizations", "0007_auto_20190506_1212")]
 
     operations = [

--- a/vng_api_common/authorizations/migrations/0009_update_enums.py
+++ b/vng_api_common/authorizations/migrations/0009_update_enums.py
@@ -19,7 +19,6 @@ def forward(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("authorizations", "0008_auto_20190712_1541")]
 
     operations = [migrations.RunPython(forward, migrations.RunPython.noop)]

--- a/vng_api_common/authorizations/migrations/0010_auto_20190712_1643.py
+++ b/vng_api_common/authorizations/migrations/0010_auto_20190712_1643.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("authorizations", "0009_update_enums")]
 
     operations = [

--- a/vng_api_common/authorizations/migrations/0011_auto_20191114_0728.py
+++ b/vng_api_common/authorizations/migrations/0011_auto_20191114_0728.py
@@ -25,7 +25,6 @@ class Renamer:
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("authorizations", "0010_auto_20190712_1643"),
     ]

--- a/vng_api_common/authorizations/migrations/0012_auto_20200619_0545.py
+++ b/vng_api_common/authorizations/migrations/0012_auto_20200619_0545.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("authorizations", "0011_auto_20191114_0728"),
     ]

--- a/vng_api_common/authorizations/migrations/0013_auto_20201207_0846.py
+++ b/vng_api_common/authorizations/migrations/0013_auto_20201207_0846.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("authorizations", "0012_auto_20200619_0545"),
     ]

--- a/vng_api_common/authorizations/migrations/0014_auto_20201221_0905.py
+++ b/vng_api_common/authorizations/migrations/0014_auto_20201221_0905.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("authorizations", "0013_auto_20201207_0846"),
     ]

--- a/vng_api_common/authorizations/migrations/0015_auto_20220318_1608.py
+++ b/vng_api_common/authorizations/migrations/0015_auto_20220318_1608.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("authorizations", "0014_auto_20201221_0905"),
     ]

--- a/vng_api_common/filters.py
+++ b/vng_api_common/filters.py
@@ -26,7 +26,6 @@ logger = logging.getLogger(__name__)
 
 
 class Backend(DjangoFilterBackend):
-
     # Taken from drf_yasg.inspectors.field.CamelCaseJSONFilter
     def _is_camel_case(self, view):
         return any(

--- a/vng_api_common/inspectors/query.py
+++ b/vng_api_common/inspectors/query.py
@@ -1,5 +1,10 @@
 from django.db import models
-from django.utils.encoding import force_text
+
+try:
+    from django.utils.encoding import force_str
+except ImportError:  # Django < 4.0
+    from django.utils.encoding import force_text as force_str
+
 from django.utils.translation import gettext as _
 
 from django_filters.filters import BaseCSVFilter, ChoiceFilter
@@ -72,7 +77,7 @@ class FilterInspector(CoreAPICompatInspector):
                     parameter.format = openapi.FORMAT_URI
 
                 if not parameter.description and help_text:
-                    parameter.description = force_text(help_text)
+                    parameter.description = force_str(help_text)
 
                 if "max_length" in filter_field.extra:
                     parameter.max_length = filter_field.extra["max_length"]

--- a/vng_api_common/middleware.py
+++ b/vng_api_common/middleware.py
@@ -215,7 +215,6 @@ class JWTAuth:
 
 
 class AuthMiddleware:
-
     header = "HTTP_AUTHORIZATION"
     auth_type = "Bearer"
 

--- a/vng_api_common/migrations/0001_initial.py
+++ b/vng_api_common/migrations/0001_initial.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/vng_api_common/migrations/0002_apicredential.py
+++ b/vng_api_common/migrations/0002_apicredential.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("vng_api_common", "0001_initial")]
 
     operations = [

--- a/vng_api_common/migrations/0003_auto_20190417_1145.py
+++ b/vng_api_common/migrations/0003_auto_20190417_1145.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("vng_api_common", "0002_apicredential")]
 
     operations = [

--- a/vng_api_common/migrations/0004_auto_20190517_0903.py
+++ b/vng_api_common/migrations/0004_auto_20190517_0903.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("vng_api_common", "0003_auto_20190417_1145")]
 
     operations = [

--- a/vng_api_common/migrations/0005_auto_20190614_1346.py
+++ b/vng_api_common/migrations/0005_auto_20190614_1346.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("vng_api_common", "0004_auto_20190517_0903")]
 
     operations = [

--- a/vng_api_common/mocks.py
+++ b/vng_api_common/mocks.py
@@ -102,7 +102,6 @@ class MockClient:
 
 
 class ZTCMockClient(MockClient):
-
     data = {
         "statustype": [
             {

--- a/vng_api_common/notifications/migrations/0001_initial.py
+++ b/vng_api_common/notifications/migrations/0001_initial.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/vng_api_common/notifications/migrations/0002_subscription__subscription.py
+++ b/vng_api_common/notifications/migrations/0002_subscription__subscription.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("notifications", "0001_initial")]
 
     operations = [

--- a/vng_api_common/notifications/migrations/0003_auto_20190319_1048.py
+++ b/vng_api_common/notifications/migrations/0003_auto_20190319_1048.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("notifications", "0002_subscription__subscription")]
 
     operations = [

--- a/vng_api_common/notifications/migrations/0004_auto_20190325_1313.py
+++ b/vng_api_common/notifications/migrations/0004_auto_20190325_1313.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("notifications", "0003_auto_20190319_1048")]
 
     operations = [

--- a/vng_api_common/notifications/migrations/0005_fix_default_nrc.py
+++ b/vng_api_common/notifications/migrations/0005_fix_default_nrc.py
@@ -17,7 +17,6 @@ def fix_config(apps, _):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("notifications", "0004_auto_20190325_1313")]
 
     operations = [migrations.RunPython(fix_config, migrations.RunPython.noop)]

--- a/vng_api_common/notifications/migrations/0006_auto_20190417_1142.py
+++ b/vng_api_common/notifications/migrations/0006_auto_20190417_1142.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("notifications", "0005_fix_default_nrc")]
 
     operations = [

--- a/vng_api_common/notifications/migrations/0007_auto_20190429_1442.py
+++ b/vng_api_common/notifications/migrations/0007_auto_20190429_1442.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("notifications", "0006_auto_20190417_1142")]
 
     operations = [

--- a/vng_api_common/notifications/migrations/0008_auto_20190502_0415.py
+++ b/vng_api_common/notifications/migrations/0008_auto_20190502_0415.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("notifications", "0007_auto_20190429_1442")]
 
     operations = [

--- a/vng_api_common/notifications/migrations/0009_auto_20190729_0427.py
+++ b/vng_api_common/notifications/migrations/0009_auto_20190729_0427.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("notifications", "0008_auto_20190502_0415")]
 
     operations = [

--- a/vng_api_common/notifications/migrations/0010_auto_20220704_1419.py
+++ b/vng_api_common/notifications/migrations/0010_auto_20220704_1419.py
@@ -34,7 +34,6 @@ def get_operation(forwards: bool = True):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("notifications", "0009_auto_20190729_0427"),
         ("notifications_api_common", "0001_initial"),


### PR DESCRIPTION
Cherry picked commits from Anna to:

* Work with latest isort and black
* Fixed a compatibility issue with Django 4.1
* Fix a migration problem due to notifications-api-common not using a migration-versioned model for some queries