### PR TITLE
support 'allOf' and 'oneOf' in schema check

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ install_requires =
     PyJWT>=2.0.0
     pyyaml
     requests
+    coreapi
 tests_require =
     pytest
     pytest-django

--- a/vng_api_common/inspectors/query.py
+++ b/vng_api_common/inspectors/query.py
@@ -30,7 +30,7 @@ class FilterInspector(CoreAPICompatInspector):
 
         if fields:
             queryset = self.view.get_queryset()
-            filter_class = filter_backend.get_filter_class(self.view, queryset)
+            filter_class = filter_backend.get_filterset_class(self.view, queryset)
 
             for parameter in fields:
                 filter_field = filter_class.base_filters[parameter.name]

--- a/vng_api_common/oas.py
+++ b/vng_api_common/oas.py
@@ -73,6 +73,10 @@ def obj_has_shape(obj: Union[list, dict], schema: dict, resource: str) -> bool:
         if "$ref" in prop_schema:
             continue
 
+        # TODO Handling allOf and oneOf not yet implemented
+        if "allOf" in prop_schema or "oneOf" in prop_schema:
+            continue
+
         # Allow None if property is nullable
         if value is None:
             if prop_schema.get("nullable", False):


### PR DESCRIPTION
**Description:**

The new ZGW standards include "oneOf" and "allOf" keywords, which are not currently supported. This PR takes care of it