### PR TITLE
🔒 Fix JWT verification

### DIFF
--- a/vng_api_common/middleware.py
+++ b/vng_api_common/middleware.py
@@ -1,7 +1,7 @@
 # https://pyjwt.readthedocs.io/en/latest/usage.html#reading-headers-without-validation
 # -> we can put the organization/service in the headers itself
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterable, List, Optional
 
 from django.conf import settings
 from django.db import models, transaction
@@ -28,7 +28,7 @@ class JWTAuth:
         self.encoded = encoded
 
     @property
-    def applicaties(self) -> Optional[list]:
+    def applicaties(self) -> Iterable[Applicatie]:
         if self.client_id is None:
             return []
 
@@ -138,7 +138,7 @@ class JWTAuth:
                 payload = jwt.decode(
                     self.encoded,
                     key,
-                    algorithms="HS256",
+                    algorithms=["HS256"],
                     leeway=settings.JWT_LEEWAY,
                 )
             except jwt.InvalidSignatureError:


### PR DESCRIPTION
A JWT has a header field `alg` that specifies the algorithm used in the signature.

PyJWT checks this with `alg in algorithms`, this "works" because `"HS256" in "HS256"` is true, but so is `"" in "HS256"` and `"HS2" in "HS256"`.

Luckily there currently are no PyJWT algorithms like that. There is no HMAC SHA2, and the Null encryption is named "none" not "".