### PR TITLE
Move zgw-consumers-oas import to related function

### DIFF
--- a/vng_api_common/tests/schema.py
+++ b/vng_api_common/tests/schema.py
@@ -6,7 +6,6 @@ from django.conf import settings
 
 import yaml
 from requests_mock import Mocker
-from zgw_consumers_oas.schema_loading import read_schema
 
 DEFAULT_PATH_PARAMETERS = {"version": "1"}
 
@@ -76,6 +75,8 @@ def get_validation_errors(response, field, index=0):
 def mock_service_oas_get(
     mock: Mocker, url: str, service: str, oas_url: str = ""
 ) -> None:
+    from zgw_consumers_oas.schema_loading import read_schema
+
     if not oas_url:
         oas_url = f"{url}schema/openapi.yaml?v=3"
 


### PR DESCRIPTION
See CI [run](https://github.com/maykinmedia/open-klant/actions/runs/12086164216/job/33704914582?pr=278#step:5:414), importing `reverse` from `commonground-api-common.tests` causes a `ModuleNotFoundError` because of the `zgw_consumers_oas` import statement. This requirement is optional and the change in this PR moves it to the function which actually requires the module.