### PR TITLE
:wrench: [#64] Fix readthedocs configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,19 +1,14 @@
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
-# Required
 version: 2
 
-# Build documentation in the docs/ directory with Sphinx
-sphinx:
-  configuration: docs/conf.py
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
 
-# Optionally build your docs in additional formats such as PDF and ePub
-formats: []
-
-# Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
   install:
     - method: pip
       path: .
@@ -22,3 +17,5 @@ python:
         - docs
         - setup-configuration
 
+sphinx:
+  configuration: docs/conf.py


### PR DESCRIPTION
fixes #64 

builds were failing due to outdated config