### PR TITLE
:zap: Cache URLs in DRF hyperlinked fields

### DIFF
--- a/testapp/urls.py
+++ b/testapp/urls.py
@@ -7,8 +7,8 @@ from drf_spectacular.views import (
     SpectacularRedocView,
     SpectacularYAMLAPIView,
 )
-from rest_framework import routers
 
+from vng_api_common import routers
 from vng_api_common.views import ViewConfigView
 
 from .viewsets import GroupViewSet, HobbyViewSet, PaginateHobbyViewSet, PersonViewSet
@@ -16,7 +16,11 @@ from .viewsets import GroupViewSet, HobbyViewSet, PaginateHobbyViewSet, PersonVi
 router = routers.DefaultRouter(trailing_slash=False)
 router.register("persons", PersonViewSet)
 router.register("hobbies", HobbyViewSet)
-router.register("groups", GroupViewSet)
+router.register(
+    "groups",
+    GroupViewSet,
+    [routers.nested("nested-person", PersonViewSet, basename="nested-person")],
+)
 router.register("paginate-hobbies", PaginateHobbyViewSet, basename="paginate-hobby")
 
 urlpatterns = [

--- a/tests/test_cached_hyperlinkrelatedfields.py
+++ b/tests/test_cached_hyperlinkrelatedfields.py
@@ -1,0 +1,127 @@
+from unittest.mock import patch
+
+from django.urls import reverse
+
+import pytest
+from rest_framework.reverse import reverse
+
+from testapp.factories import GroupFactory, PersonFactory
+
+
+@pytest.mark.django_db
+def test_cached_hyperlinkedrelatedfield(api_client):
+    """
+    Caching is applied to the base URI for each view in CachedHyperlinkedRelatedField,
+    but this cache must be only be applied within the same requests, to ensure that
+    requests with different HTTP_HOSTs show the correct domain in their responses
+    """
+    group = GroupFactory.create(name="group1")
+    person = PersonFactory.create(
+        name="John Doe", address_street="Foo", address_number="1", group=group
+    )
+
+    response = api_client.get(reverse("person-detail", kwargs={"pk": person.pk}))
+
+    expected = {
+        "url": f"http://testserver{reverse('person-detail', kwargs={'pk': person.pk})}",
+        "address": {"street": "Foo", "number": "1"},
+        "name": "John Doe",
+        "group_name": "group1",
+        "group_url": f"http://testserver{reverse('group-detail', kwargs={'pk': group.pk})}",
+    }
+
+    assert response.data == expected
+
+    response = api_client.get(
+        reverse("person-detail", kwargs={"pk": person.pk}), HTTP_HOST="different.local"
+    )
+
+    expected = {
+        "url": f"http://different.local{reverse('person-detail', kwargs={'pk': person.pk})}",
+        "address": {"street": "Foo", "number": "1"},
+        "name": "John Doe",
+        "group_name": "group1",
+        "group_url": f"http://different.local{reverse('group-detail', kwargs={'pk': group.pk})}",
+    }
+
+    assert response.data == expected
+
+
+@pytest.mark.django_db
+def test_cached_nested_hyperlinkedrelatedfield(api_client):
+    """
+    Caching is applied to the base URI for each view in CachedNestedHyperlinkedRelatedField,
+    but this cache must be only be applied within the same requests, to ensure that
+    requests with different HTTP_HOSTs show the correct domain in their responses
+    """
+    group = GroupFactory.create(name="group1")
+    person1 = PersonFactory.create(
+        name="John Doe", address_street="Foo", address_number="1", group=group
+    )
+    person2 = PersonFactory.create(
+        name="Jane Doe", address_street="Bar", address_number="2", group=group
+    )
+
+    with patch("rest_framework.relations.reverse", side_effect=reverse) as mock_reverse:
+        response = api_client.get(reverse("group-detail", kwargs={"pk": group.pk}))
+
+        # Without caching 6 calls would be made to reverse, caching reduces this to 3
+        # (one for each view)
+        assert mock_reverse.call_count == 3
+        assert mock_reverse.call_args_list[0].args == ("person-detail",)
+        assert mock_reverse.call_args_list[1].args == ("group-detail",)
+        assert mock_reverse.call_args_list[2].args == ("nested-person-detail",)
+
+    expected = {
+        "persons": [
+            {
+                "url": f"http://testserver{reverse('person-detail', kwargs={'pk': person1.pk})}",
+                "address": {"street": "Foo", "number": "1"},
+                "name": "John Doe",
+                "group_name": "group1",
+                "group_url": f"http://testserver{reverse('group-detail', kwargs={'pk': group.pk})}",
+            },
+            {
+                "url": f"http://testserver{reverse('person-detail', kwargs={'pk': person2.pk})}",
+                "address": {"street": "Bar", "number": "2"},
+                "name": "Jane Doe",
+                "group_name": "group1",
+                "group_url": f"http://testserver{reverse('group-detail', kwargs={'pk': group.pk})}",
+            },
+        ],
+        "nested_persons": [
+            f"http://testserver{reverse('nested-person-detail', kwargs={'group_pk': group.pk, 'pk': person1.pk})}",
+            f"http://testserver{reverse('nested-person-detail', kwargs={'group_pk': group.pk, 'pk': person2.pk})}",
+        ],
+    }
+
+    assert response.data == expected
+
+    response = api_client.get(
+        reverse("group-detail", kwargs={"pk": group.pk}), HTTP_HOST="different.local"
+    )
+
+    expected = {
+        "persons": [
+            {
+                "url": f"http://different.local{reverse('person-detail', kwargs={'pk': person1.pk})}",
+                "address": {"street": "Foo", "number": "1"},
+                "name": "John Doe",
+                "group_name": "group1",
+                "group_url": f"http://different.local{reverse('group-detail', kwargs={'pk': group.pk})}",
+            },
+            {
+                "url": f"http://different.local{reverse('person-detail', kwargs={'pk': person2.pk})}",
+                "address": {"street": "Bar", "number": "2"},
+                "name": "Jane Doe",
+                "group_name": "group1",
+                "group_url": f"http://different.local{reverse('group-detail', kwargs={'pk': group.pk})}",
+            },
+        ],
+        "nested_persons": [
+            f"http://different.local{reverse('nested-person-detail', kwargs={'group_pk': group.pk, 'pk': person1.pk})}",
+            f"http://different.local{reverse('nested-person-detail', kwargs={'group_pk': group.pk, 'pk': person2.pk})}",
+        ],
+    }
+
+    assert response.data == expected

--- a/tests/test_gegevensgroepen.py
+++ b/tests/test_gegevensgroepen.py
@@ -1,3 +1,5 @@
+from rest_framework.test import APIRequestFactory
+
 from testapp.models import Group, Person
 from testapp.serializers import PersonSerializer, PersonSerializer2
 
@@ -93,7 +95,11 @@ def test_assignment_missing_optional_key():
 
 def test_nullable_gegevensgroep():
     person = Person(name="bla", address_street="", address_number="")
-    output = PersonSerializer().to_representation(instance=person)
+    factory = APIRequestFactory()
+    request = factory.get("/persons")
+    output = PersonSerializer(context={"request": request}).to_representation(
+        instance=person
+    )
     assert output["address"] == {
         "street": "",
         "number": "",

--- a/tests/test_nested_serializer_validation.py
+++ b/tests/test_nested_serializer_validation.py
@@ -43,7 +43,7 @@ def test_create_invalid_params():
     """
     serializer = GroupSerializer(
         data={
-            "person": [
+            "persons": [
                 {
                     "name": "john",
                     "address": {"street": "Keizersgracht", "number": "416"},
@@ -59,17 +59,17 @@ def test_create_invalid_params():
 
     validation_errors = list(get_validation_errors(serializer.errors))
 
-    assert validation_errors[0]["name"] == "person.1.address.street"
+    assert validation_errors[0]["name"] == "persons.1.address.street"
     assert validation_errors[0]["code"] == "required"
 
-    assert validation_errors[1]["name"] == "person.2.name"
+    assert validation_errors[1]["name"] == "persons.2.name"
     assert validation_errors[1]["code"] == "required"
 
 
 def test_create_valid():
     serializer = GroupSerializer(
         data={
-            "person": [
+            "persons": [
                 {
                     "name": "test",
                     "address": {"street": "Keizersgracht", "number": "117"},

--- a/vng_api_common/authorizations/utils.py
+++ b/vng_api_common/authorizations/utils.py
@@ -12,6 +12,7 @@ def generate_jwt(client_id, secret, user_id, user_representation):
             secret=secret,
             user_id=user_id,
             user_representation=user_representation,
+            jwt_valid_for=5 * 60,
         )
     )
     return f"Bearer {auth._token}"


### PR DESCRIPTION
Related issue: https://github.com/open-zaak/open-zaak/issues/1970
Related PR in OZ: https://github.com/open-zaak/open-zaak/pull/1969

These changes allow the results of `reverse()` for each view name to be cached on the field instance, this means that when serializing a list of for instance 100 Zaken, the logic to figure out the base part of the zaak-detail url (for the `"url"` attribute, `/zaken/api/v1/zaken/...`) is only performed once per request. This same caching can be applied for HyperlinkedRelatedFields, so we can save a decent bit of CPU time with this.

The reason I store the cache on the field instance itself is to ensure this cache doesn't persist between API requests, because if requests are done with a different domain, this should be reflected in the API response as well (if the application is hosted on multiple domains for example)