### PR TITLE
:recycle: Migrate from iso639 to iso639-lang

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ install_requires =
     django-rest-framework-condition
     drf-nested-routers>=0.94.1
     drf-spectacular
-    iso-639
+    iso639-lang
     notifications-api-common>=0.3.1
     zgw-consumers>=0.35.1
     oyaml

--- a/vng_api_common/fields.py
+++ b/vng_api_common/fields.py
@@ -5,16 +5,12 @@ from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 from django.utils.translation import gettext, gettext_lazy as _
 
-from iso639 import languages
+from iso639 import iter_langs
 
 from .constants import BSN_LENGTH, RSIN_LENGTH, VertrouwelijkheidsAanduiding
 from .validators import validate_rsin
 
-ISO_639_2B = languages.part2b
-
-LANGUAGE_CHOICES = tuple(
-    [(code, language.name) for code, language in ISO_639_2B.items()]
-)
+LANGUAGE_CHOICES = tuple([(lg.pt2b, lg.name) for lg in iter_langs() if lg.pt2b])
 
 
 class RSINField(models.CharField):


### PR DESCRIPTION
Migrate from `iso639` to `iso639-lang`, so the `pkg_resources` package is no longer required when trying to upgrade to `python12`

`iso639-lang` is compatible with python >= 3.9
https://pypi.org/project/iso639-lang/

Necessary for this PR in OpenKlant: https://github.com/maykinmedia/open-klant/pull/404