### PR TITLE
:recycle: No longer rely on zgw-consumers for generate_jwt util

### DIFF
--- a/vng_api_common/authorizations/utils.py
+++ b/vng_api_common/authorizations/utils.py
@@ -1,18 +1,27 @@
-def generate_jwt(client_id, secret, user_id, user_representation):
-    from zgw_consumers.client import ZGWAuth
+import time
 
-    class FakeService:
-        def __init__(self, **kwargs):
-            for key, value in kwargs.items():
-                setattr(self, key, value)
+import jwt
 
-    auth = ZGWAuth(
-        service=FakeService(  # type: ignore
-            client_id=client_id,
-            secret=secret,
-            user_id=user_id,
-            user_representation=user_representation,
-            jwt_valid_for=5 * 60,
-        )
-    )
-    return f"Bearer {auth._token}"
+
+def generate_jwt(
+    client_id: str,
+    secret: str,
+    user_id: str,
+    user_representation: str,
+    jwt_valid_for: int | None = None,
+) -> str:
+    iat = int(time.time())
+    payload = {
+        # standard claims
+        "iss": client_id,
+        "iat": iat,
+        # custom claims
+        "client_id": client_id,
+        "user_id": user_id,
+        "user_representation": user_representation,
+    }
+    if jwt_valid_for:
+        payload["exp"] = iat + jwt_valid_for
+
+    token = jwt.encode(payload, secret, algorithm="HS256")
+    return f"Bearer {token}"


### PR DESCRIPTION
Required for https://github.com/open-zaak/open-zaak/pull/1932

this previously used zgw_consumers ZGWAuth, which was a bit of a hack and also caused issues because the exp claim has been added there, which affects tests in Open Zaak. The util is now implemented properly and can optionally add the exp claim as well