### PR TITLE
:heavy_minus_sign: [#105] Remove coreapi dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,6 @@ install_requires =
     oyaml
     PyJWT>=2.10.1
     requests
-    coreapi
     ape-pie
 tests_require =
     pytest


### PR DESCRIPTION
fixes #105 

this was mentioned by DRF as required for the API docs, but drf-spectacular does not seem to need this