### PR TITLE
:speech_balloon: [open-zaak/open-zaak#2261] Mark afleidingswijze gerelateerde_zaak as deprecated

### DIFF
--- a/vng_api_common/constants.py
+++ b/vng_api_common/constants.py
@@ -129,7 +129,10 @@ class BrondatumArchiefprocedureAfleidingswijze(TextChoicesWithDescriptions):
     afgehandeld = "afgehandeld", _("Afgehandeld")
     ander_datumkenmerk = "ander_datumkenmerk", _("Ander datumkenmerk")
     eigenschap = "eigenschap", _("Eigenschap")
-    gerelateerde_zaak = "gerelateerde_zaak", _("Gerelateerde zaak")
+    gerelateerde_zaak = (
+        "gerelateerde_zaak",
+        _("**EXPERIMENTEEL DEPRECATED**: Gerelateerde zaak"),
+    )
     hoofdzaak = "hoofdzaak", _("Hoofdzaak")
     ingangsdatum_besluit = "ingangsdatum_besluit", _("Ingangsdatum besluit")
     termijn = "termijn", _("Termijn")


### PR DESCRIPTION
Related issue open-zaak/open-zaak#2261

also experimental, because this is a deviation from the VNG Catalogi API spec