### PR TITLE
:green_heart: Ensure psycopg2 is installed for ReadTheDocs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,6 +16,7 @@ python:
     - method: pip
       path: .
       extra_requirements:
+        - db
         - notifications
         - docs
         - setup-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,8 @@ drf_extra_fields = [
     "drf-extra-fields>=3.7.0",
 ]
 
+db = ["psycopg2"]
+
 tests = [
     "psycopg2",
     "pytest",


### PR DESCRIPTION
Noticed that readthedocs wasn't updating anymore: https://app.readthedocs.org/projects/commonground-api-common/builds/33497719/

Type checking failures will be fixed by: https://github.com/maykinmedia/commonground-api-common/pull/171